### PR TITLE
Analyze how met data drive calculated disturbance metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ ED-outputs/exp-constant/*
 ED-outputs/met_results/*
 ED-outputs/results/exp-constant-mon.csv
 _drake.R
+
+# RPubs
+*.dcf

--- a/metric_analysis.Rmd
+++ b/metric_analysis.Rmd
@@ -14,12 +14,24 @@ date: "`r format(Sys.time(), '%d %B, %Y')`"
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
 
+set.seed(1234)
+
 library(dplyr)
 
 library(readr)
 resistance <- read_csv("ED-outputs/results/metric/resistance_values.csv")
 resilience <- read_csv("ED-outputs/results/metric/resilience_values.csv")
 met <- read_csv("ED-outputs/results/constant_annual_met_data.csv")
+
+resistance %>% 
+  select(scn, variable, met, value = trough_resistance, severity) %>% 
+  mutate(metric = "resistance") ->
+  combined
+resilience %>% 
+  select(scn, variable, met, value = resilience, severity) %>% 
+  mutate(metric = "resilience") %>% 
+  bind_rows(combined) ->
+  combined
 ```
 
 # Met data
@@ -63,32 +75,51 @@ ggplot(resilience, aes(resilience, fill = severity)) +
   facet_wrap(~variable)
 ```
 
-# Met-metric data
+# Met-metric data {.tabset}
 
 We see from the met analysis above that vbdsf and vddsf are highly
 correlated with nbdsf and nddsf respectively; remove one pair.
 
 Take a first look at the relationship between output variables and met variables.
 
+## Resistance
+
 ```{r, fig.height=8}
 # Build a combined met-metric dataset
-resistance %>% 
-  select(variable, met, trough_resistance) %>% 
+combined %>% 
+  select(metric, variable, met, value) %>% 
   # We see from the met analysis above that vbdsf and vddsf are highly
   # correlated with nbdsf and nddsf respectively; remove one pair
   left_join(select(met2_wide, -nbdsf, -nddsf), by = "met") ->
+  metric_combined
+
+resistance %>% 
+  select(variable, met, trough_resistance) %>% 
+  left_join(select(met2_wide, -nbdsf, -nddsf), by = "met") ->
   resist_combined
 
-resist_combined %>% 
-  pivot_longer(dlwrf:vgrd) %>% 
-  ggplot(aes(value, trough_resistance, color = variable)) +
+metric_combined %>% 
+  pivot_longer(dlwrf:vgrd, values_to = "met_value") ->
+  metric_comb_long
+
+p_mm <- ggplot(filter(metric_comb_long, metric == "resistance"), 
+            aes(met_value, value, color = variable)) +
   geom_point() + 
-  facet_wrap(variable~name, scales = "free") + 
   geom_smooth(method = "lm", formula = y ~ x, color = "black", linetype = 5) +
+  facet_wrap(~ variable + name, scales = "free") + 
+  ggtitle("Resistance") +
   theme(legend.position = "none", axis.text = element_text(size = 5))
+print(p_mm)
 ```
 
-# Variable importance
+## Resilience
+
+```{r, fig.height=8}
+p_mm <- p_mm %+% filter(metric_comb_long, metric == "resilience")
+print(p_mm + ggtitle("Resilience"))
+```
+
+# Variable importance {.tabset}
 
 Fit a Random Forest model to each output variable (GPP, etc.) and then calculate
 variable importance for each model. Make partial dependence plots for the
@@ -98,9 +129,10 @@ three most important met variables for each output variable.
 # Fit a Random Forest for each variable (across all treatment severities)
 # Note the r.f. functions don't play well with tibbles, so change to data frame
 library(randomForest)
-rc_all <- split(as.data.frame(resist_combined), resist_combined$variable)
+rc_all <- split(as.data.frame(metric_combined), ~ metric + variable)
 rf_all <- lapply(rc_all, function(x) 
-  randomForest(trough_resistance ~ ., data = x[-1:-2], importance = TRUE)
+  # remove metric, variable, met columns and run RF
+  randomForest(value ~ ., data = x[-1:-3], importance = TRUE)
 )
 
 # Importance metrics and partial plot data
@@ -108,42 +140,68 @@ import <- list()
 partial <- list()
 for(var in names(rf_all)) {
   mod <- rf_all[[var]]
+  metric <- rc_all[[var]]$metric[1]
+  variable <- rc_all[[var]]$variable[1]
+  
   imp <- as.data.frame(importance(mod))
   imp$met_var <- rownames(imp)
+  imp$metric <- metric
+  imp$variable <- variable
   import[[var]] <- as_tibble(imp)
   
   impvar <- rownames(imp)[order(imp[, 1], decreasing = TRUE)]
   for (i in seq_along(impvar[1:3])) {
     pp <- partialPlot(mod, rc_all[[var]], impvar[i], plot = FALSE)
-    partial[[paste(var, i)]] <- tibble(var = var, 
+    partial[[paste(var, i)]] <- tibble(metric = metric,
+                                       variable = variable,
                                        met_var = impvar[i],
                                        x = pp$x, y = pp$y)
   }
 }
 
-import <- bind_rows(import, .id = "var")
+import <- bind_rows(import)
+partial <- bind_rows(partial)
+```
+
+## Resistance
+
+```{r}
 library(forcats)
-lapply(split(import, import$var), function(x) {
+f_imp_plot <- function(x) {
   ggplot(x, aes(fct_reorder(met_var, `%IncMSE`), `%IncMSE`)) + 
     geom_col() +
     coord_flip() +
     xlab("Met variable") +
-    ggtitle(unique(x$var))
-})
+    ggtitle(unique(x$variable))
+}
+lapply(split(filter(import, metric == "resistance"), ~ variable), f_imp_plot)
 
-partial <- bind_rows(partial)
-ggplot(bind_rows(partial), aes(x, y, color = var)) + 
+p_pdp <- ggplot(filter(partial, metric == "resistance"), 
+                aes(x, y, color = variable)) + 
   geom_line() + 
-  xlab("Met var value") + ylab("Metric") +
+  xlab("Met var value") + ylab("Resistance") +
   ggtitle("Partial dependence plot") +
-  facet_grid(var ~ met_var, scales = "free")
+  facet_grid(variable ~ met_var, scales = "free")
+print(p_pdp)
+```
+
+## Resilience
+
+```{r}
+# Re-do above plots but now for resilience
+lapply(split(filter(import, metric == "resilience"), ~ variable), f_imp_plot)
+p_pdp <- p_pdp %+% filter(partial, metric == "resilience")
+print(p_pdp + ylab("Resilience"))
 ```
 
 # Summary
 
-Interestingly, `tmp` (air temperature) and `vbdsf` (sunlight) are among the
+For **resistance**, `tmp` (air temperature) and `vbdsf` (sunlight) are among the
 top-three most important drivers for all four output variables 
-(GPP, NEP, NPP, Rh) for resistance. Atmospheric pressure (`pres`) is
-among the top three for both GPP and NPP resistance: the former because of
-stomatal effects perhaps (?), and the latter because
-of NPP's strong dependence on GPP.
+(GPP, NEP, NPP, Rh). Higher temperature and more light translate into higher
+resistance for all variables.
+
+This is largely true for **resilience** as well, although
+`prate` (precipitation) is important for both NPP and Rh; in fact precipitation
+is far and away the most important variable for Rh. Here, however,
+higher temperature and more light mean _less_ resilience.

--- a/metric_analysis.Rmd
+++ b/metric_analysis.Rmd
@@ -17,7 +17,8 @@ knitr::opts_chunk$set(echo = TRUE)
 library(dplyr)
 
 library(readr)
-resist <- read_csv("ED-outputs/results/metric/resistance_values.csv")
+resistance <- read_csv("ED-outputs/results/metric/resistance_values.csv")
+resilience <- read_csv("ED-outputs/results/metric/resilience_values.csv")
 met <- read_csv("ED-outputs/results/constant_annual_met_data.csv")
 ```
 
@@ -43,7 +44,7 @@ ggplot(met2, aes(met, value)) +
 
 library(tidyr)
 met2_wide <- pivot_wider(met2, id_cols = "met", names_from = "variable")
-pca_met <- prcomp(met2_wide[-1], scale. = TRUE)
+pca_met <- prcomp(met2_wide[-1], scale. = TRUE)  # -1 removes met year column 
 biplot(pca_met, scale = 0)
 pairs(met2_wide[-1])
 ```
@@ -51,8 +52,14 @@ pairs(met2_wide[-1])
 # Metric data
 
 ```{r}
-ggplot(resist, aes(trough_resistance, fill = severity)) +
+ggplot(resistance, aes(trough_resistance, fill = severity)) +
   geom_histogram(bins = 20) + 
+  ggtitle("Resistance") +
+  facet_wrap(~variable)
+
+ggplot(resilience, aes(resilience, fill = severity)) +
+  geom_histogram(bins = 20) + 
+  ggtitle("Resilience") +
   facet_wrap(~variable)
 ```
 
@@ -65,7 +72,7 @@ Take a first look at the relationship between output variables and met variables
 
 ```{r, fig.height=8}
 # Build a combined met-metric dataset
-resist %>% 
+resistance %>% 
   select(variable, met, trough_resistance) %>% 
   # We see from the met analysis above that vbdsf and vddsf are highly
   # correlated with nbdsf and nddsf respectively; remove one pair
@@ -74,10 +81,10 @@ resist %>%
 
 resist_combined %>% 
   pivot_longer(dlwrf:vgrd) %>% 
-  ggplot(aes(trough_resistance, value, color = variable)) +
+  ggplot(aes(value, trough_resistance, color = variable)) +
   geom_point() + 
-  facet_wrap(variable~name, scales = "free_y") + 
-  geom_smooth(method = "lm", formula = y ~ x) +
+  facet_wrap(variable~name, scales = "free") + 
+  geom_smooth(method = "lm", formula = y ~ x, color = "black", linetype = 5) +
   theme(legend.position = "none", axis.text = element_text(size = 5))
 ```
 
@@ -140,4 +147,3 @@ top-three most important drivers for all four output variables
 among the top three for both GPP and NPP resistance: the former because of
 stomatal effects perhaps (?), and the latter because
 of NPP's strong dependence on GPP.
-

--- a/metric_analysis.Rmd
+++ b/metric_analysis.Rmd
@@ -1,0 +1,87 @@
+---
+title: "metric analysis"
+output:
+  html_document:
+    df_print: paged
+    toc: yes
+    toc_depth: '4'
+    toc_float: yes
+    number_sections: true
+    code_folding: hide
+date: "`r format(Sys.time(), '%d %B, %Y')`"
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+
+library(dplyr)
+
+library(readr)
+resist <- read_csv("ED-outputs/results/metric/resistance_values.csv")
+met <- read_csv("ED-outputs/results/constant_annual_met_data.csv")
+```
+
+# Met data
+
+```{r, echo=FALSE}
+met %>% 
+  # hgt is constant; remove
+  filter(variable != "hgt") %>%   
+  group_by(met, variable) %>% 
+  summarise(value = mean(value), .groups = "drop") ->
+  met2
+
+library(ggplot2)
+theme_set(theme_minimal())
+ggplot(met2, aes(met, value)) +
+  geom_point() + 
+  facet_wrap(~variable, scales = "free_y") +
+  theme(axis.text.x = element_text(angle = 90))
+
+library(tidyr)
+met2_wide <- pivot_wider(met2, id_cols = "met", names_from = "variable")
+pca_met <- prcomp(met2_wide[-1], scale. = TRUE)
+biplot(pca_met, scale = 0)
+pairs(met2_wide[-1])
+```
+
+# Metric data
+
+```{r}
+ggplot(resist, aes(trough_resistance, fill = severity)) +
+  geom_histogram(bins = 20) + 
+  facet_wrap(~variable)
+```
+
+# Variable importance
+
+```{r, fig.height=8}
+# Build a combined met-metric dataset
+resist %>% 
+  select(variable, met, trough_resistance) %>% 
+  # We see from the met analysis above that vbdsf and vddsf are highly
+  # correlated with nbdsf and nddsf respectively; remove one pair
+  left_join(select(met2_wide, -nbdsf, -nddsf), by = "met") ->
+  resist_combined
+
+resist_combined %>% 
+  pivot_longer(dlwrf:vgrd) %>% 
+  ggplot(aes(trough_resistance, value, color = variable)) +
+  geom_point() + 
+  facet_wrap(variable~name, scales="free_y") + 
+  geom_smooth(method = "lm", formula = y ~ x) +
+  theme(legend.position = "none", axis.text = element_text(size = 5))
+
+# Fit a Random Forest for each variable
+rc_all <- split(resist_combined, resist_combined$variable)
+rf_all <- lapply(rc_all, function(x) 
+  randomForest(trough_resistance ~ ., data = x[-1:-2], importance = TRUE)
+)
+imp_all <- lapply(rf_all, function(x) {
+  imp <- as.data.frame(importance(x))
+  imp$met_var <- rownames(imp)
+  as_tibble(imp)
+})
+importance <- bind_rows(imp_all, .id = "variable")
+```
+

--- a/metric_analysis.Rmd
+++ b/metric_analysis.Rmd
@@ -72,16 +72,39 @@ resist_combined %>%
   geom_smooth(method = "lm", formula = y ~ x) +
   theme(legend.position = "none", axis.text = element_text(size = 5))
 
-# Fit a Random Forest for each variable
-rc_all <- split(resist_combined, resist_combined$variable)
+# Fit a Random Forest for each variable (across all treatment severities)
+# Note the r.f. functions don't play well with tibbles, so change to data frame
+rc_all <- split(as.data.frame(resist_combined), resist_combined$variable)
 rf_all <- lapply(rc_all, function(x) 
   randomForest(trough_resistance ~ ., data = x[-1:-2], importance = TRUE)
 )
-imp_all <- lapply(rf_all, function(x) {
-  imp <- as.data.frame(importance(x))
+
+# Importance metrics and partial plot data
+import <- list()
+partial <- list()
+for(var in names(rf_all)) {
+  mod <- rf_all[[var]]
+  imp <- as.data.frame(importance(mod))
   imp$met_var <- rownames(imp)
-  as_tibble(imp)
-})
-importance <- bind_rows(imp_all, .id = "variable")
+  import[[var]] <- as_tibble(imp)
+
+  impvar <- rownames(imp)[order(imp[, 1], decreasing = TRUE)]
+  for (i in seq_along(impvar)) {
+    pp <- partialPlot(mod, rc_all[[var]], impvar[i], plot = FALSE)
+    partial[[paste(var, i)]] <- tibble(var = var, 
+                                       met_var = impvar[i],
+                                       x = pp$x, y = pp$y)
+  }
+}
+
+import <- bind_rows(import, .id = "var")
+ggplot(import, aes(met_var, `%IncMSE`)) + geom_col() +
+  coord_flip() +
+  facet_wrap(~var)
+
+partial <- bind_rows(partial)
+ggplot(bind_rows(partial), aes(x, y, color = var)) + 
+  geom_line() + 
+  facet_wrap(~var + met_var, scales = "free")
 ```
 

--- a/metric_analysis.Rmd
+++ b/metric_analysis.Rmd
@@ -103,7 +103,7 @@ metric_combined %>%
   metric_comb_long
 
 p_mm <- ggplot(filter(metric_comb_long, metric == "resistance"), 
-            aes(met_value, value, color = variable)) +
+               aes(met_value, value, color = variable)) +
   geom_point() + 
   geom_smooth(method = "lm", formula = y ~ x, color = "black", linetype = 5) +
   facet_wrap(~ variable + name, scales = "free") + 
@@ -174,7 +174,12 @@ f_imp_plot <- function(x) {
     xlab("Met variable") +
     ggtitle(unique(x$variable))
 }
-lapply(split(filter(import, metric == "resistance"), ~ variable), f_imp_plot)
+xx <- lapply(split(filter(import, metric == "resistance"), ~ variable), f_imp_plot)
+
+library(cowplot)
+varimp_plot <- plot_grid(xx[["GPP"]], xx[["NEP"]], xx[["NPP"]], xx[["Rh"]])
+print(varimp_plot)
+save_plot("varimp_resistance.png", varimp_plot)
 
 p_pdp <- ggplot(filter(partial, metric == "resistance"), 
                 aes(x, y, color = variable)) + 
@@ -189,12 +194,28 @@ print(p_pdp)
 
 ```{r}
 # Re-do above plots but now for resilience
-lapply(split(filter(import, metric == "resilience"), ~ variable), f_imp_plot)
+xx <- lapply(split(filter(import, metric == "resilience"), ~ variable), f_imp_plot)
+varimp_plot <- plot_grid(xx[["GPP"]], xx[["NEP"]], xx[["NPP"]], xx[["Rh"]])
+print(varimp_plot)
+save_plot("varimp_resilience.png", varimp_plot)
+
 p_pdp <- p_pdp %+% filter(partial, metric == "resilience")
 print(p_pdp + ylab("Resilience"))
 ```
 
 # Summary
+
+```{r}
+# Combined partial dependence plot
+partial %>% 
+  mutate(metric = if_else(metric == "resistance", "Resistance", "Resilience")) %>% 
+  ggplot(aes(x, y, color = variable)) + 
+  geom_line() + 
+  xlab("Meteorological variable value") + ylab("Metric value") +
+  scale_color_discrete("") +
+  facet_grid(metric ~ met_var, scales = "free") +
+  theme(axis.text.x = element_text(angle = 90))
+```
 
 For **resistance**, `tmp` (air temperature) and `vbdsf` (sunlight) are among the
 top-three most important drivers for all four output variables 

--- a/metric_analysis.Rmd
+++ b/metric_analysis.Rmd
@@ -23,6 +23,9 @@ met <- read_csv("ED-outputs/results/constant_annual_met_data.csv")
 
 # Met data
 
+Take a look at the distribution of met data, and perform a Principal Components
+Analysis (PCA) to examine auto-correlation between the various met variables.
+
 ```{r, echo=FALSE}
 met %>% 
   # hgt is constant; remove
@@ -53,7 +56,12 @@ ggplot(resist, aes(trough_resistance, fill = severity)) +
   facet_wrap(~variable)
 ```
 
-# Variable importance
+# Met-metric data
+
+We see from the met analysis above that vbdsf and vddsf are highly
+correlated with nbdsf and nddsf respectively; remove one pair.
+
+Take a first look at the relationship between output variables and met variables.
 
 ```{r, fig.height=8}
 # Build a combined met-metric dataset
@@ -68,12 +76,21 @@ resist_combined %>%
   pivot_longer(dlwrf:vgrd) %>% 
   ggplot(aes(trough_resistance, value, color = variable)) +
   geom_point() + 
-  facet_wrap(variable~name, scales="free_y") + 
+  facet_wrap(variable~name, scales = "free_y") + 
   geom_smooth(method = "lm", formula = y ~ x) +
   theme(legend.position = "none", axis.text = element_text(size = 5))
+```
 
+# Variable importance
+
+Fit a Random Forest model to each output variable (GPP, etc.) and then calculate
+variable importance for each model. Make partial dependence plots for the
+three most important met variables for each output variable.
+
+```{r, message=FALSE}
 # Fit a Random Forest for each variable (across all treatment severities)
 # Note the r.f. functions don't play well with tibbles, so change to data frame
+library(randomForest)
 rc_all <- split(as.data.frame(resist_combined), resist_combined$variable)
 rf_all <- lapply(rc_all, function(x) 
   randomForest(trough_resistance ~ ., data = x[-1:-2], importance = TRUE)
@@ -87,9 +104,9 @@ for(var in names(rf_all)) {
   imp <- as.data.frame(importance(mod))
   imp$met_var <- rownames(imp)
   import[[var]] <- as_tibble(imp)
-
+  
   impvar <- rownames(imp)[order(imp[, 1], decreasing = TRUE)]
-  for (i in seq_along(impvar)) {
+  for (i in seq_along(impvar[1:3])) {
     pp <- partialPlot(mod, rc_all[[var]], impvar[i], plot = FALSE)
     partial[[paste(var, i)]] <- tibble(var = var, 
                                        met_var = impvar[i],
@@ -98,13 +115,29 @@ for(var in names(rf_all)) {
 }
 
 import <- bind_rows(import, .id = "var")
-ggplot(import, aes(met_var, `%IncMSE`)) + geom_col() +
-  coord_flip() +
-  facet_wrap(~var)
+library(forcats)
+lapply(split(import, import$var), function(x) {
+  ggplot(x, aes(fct_reorder(met_var, `%IncMSE`), `%IncMSE`)) + 
+    geom_col() +
+    coord_flip() +
+    xlab("Met variable") +
+    ggtitle(unique(x$var))
+})
 
 partial <- bind_rows(partial)
 ggplot(bind_rows(partial), aes(x, y, color = var)) + 
   geom_line() + 
-  facet_wrap(~var + met_var, scales = "free")
+  xlab("Met var value") + ylab("Metric") +
+  ggtitle("Partial dependence plot") +
+  facet_grid(var ~ met_var, scales = "free")
 ```
+
+# Summary
+
+Interestingly, `tmp` (air temperature) and `vbdsf` (sunlight) are among the
+top-three most important drivers for all four output variables 
+(GPP, NEP, NPP, Rh) for resistance. Atmospheric pressure (`pres`) is
+among the top three for both GPP and NPP resistance: the former because of
+stomatal effects perhaps (?), and the latter because
+of NPP's strong dependence on GPP.
 


### PR DESCRIPTION
This PR adds a standalone `metric_analysis.Rmd` file (didn't integrate it into your drake pipeline, sorry) that analyzes the relationship between disturbance metrics and their meteorological inputs. The code:
* looks for autocorrelation among the met variables and removes a few
* fits Random Forest models for each variable (GPP, NPP, NEP, and Rh) and metric, and 
* produces plots showing variable importance and partial dependence of the most important met variables for each output variable.

I have posted the Rmd output here: https://rpubs.com/bpbond/775538